### PR TITLE
fix: queueing chunks up on load

### DIFF
--- a/resources/assets/livemap/lang/en.json
+++ b/resources/assets/livemap/lang/en.json
@@ -1,34 +1,28 @@
 ﻿{
   "command.description": "Get a link to the livemap",
   "command.no-args-response": "View our livemap at <a href=\"{0}\">{0}</a>",
-
   "command.error.no-privilege": "Sorry, you don't have the privilege to use this command",
   "command.error.player-only-command": "Sorry, only players can run this command",
-
   "command.arg.apothem": "the range (in blocks) to render",
   "command.arg.center": "the center position (local coordinates)",
-
   "command.apothemrender.description": "Queue up generated regions in range around a position/player for renderer. This does not generate new land",
   "command.apothemrender.out-of-bounds": "Apothem out of bounds",
   "command.apothemrender.missing-center-or-player": "Command requires a center position or a player",
   "command.apothemrender.started": "Apothemrender task has started",
-
   "command.colormap.description": "Sends a request to your client to generate a new colormap. This requires LiveMap mod to also be installed on your client. Your client will generate a new colormap and then send it back to the server.",
   "command.colormap.requested": "Requesting colormap from client",
   "command.colormap.received": "Received colormap from client",
   "command.colormap.empty": "Received an empty colormap from client. Try again",
-
   "command.fullrender.description": "Queue up all generated regions in the entire world for renderer. This does not generate new land",
   "command.fullrender.missing-colormap": "Error: Missing colormap. Please run <a href=\"chattype:///livemap colormap\">/livemap colormap</a> first",
   "command.fullrender.started": "Fullrender task has started",
-
   "command.reload.description": "Reload the mod configuration from disk",
   "command.reload.done": "LiveMap config has been reloaded",
-
   "command.status.description": "View current renderer status",
   "command.status.idle": "Renderers idle (queued: {0})",
   "command.status.running": "Renderers running (remaining: {0})",
-
+  "command.queue.description": "View current render queue status",
+  "command.help.description": "View help for a specific command",
   "lang.pinned": "Pinned",
   "lang.unpinned": "Unpinned",
   "lang.players": "Players",

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
   "type": "code",
   "name": "LiveMap",
   "modid": "livemap",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "LiveMap is a browser-based world map viewer for Vintage Story",
   "authors": [
     "BillyGalbreath",

--- a/src/LiveMap.cs
+++ b/src/LiveMap.cs
@@ -70,6 +70,7 @@ public sealed class LiveMap {
         WebServer = new WebServer(this);
 
         api.Event.ChunkDirty += OnChunkDirty;
+        api.Event.ChunkColumnLoaded += OnChunkColumnLoaded;
         api.Event.GameWorldSave += OnGameWorldSave;
 
         // things to do on first game tick
@@ -123,7 +124,13 @@ public sealed class LiveMap {
 
     private void OnChunkDirty(Vec3i chunkCoord, IWorldChunk chunk, EnumChunkDirtyReason reason) {
         // queue it up, it will process when the game saves
+        Logger.Debug($"Chunk dirty: {chunkCoord}");
         RenderTaskManager?.Queue(chunkCoord.X >> 4, chunkCoord.Z >> 4);
+    }
+
+    private void OnChunkColumnLoaded(Vec2i chunkCoord, IWorldChunk[] chunks) {
+        Logger.Debug($"Chunk loaded: {chunkCoord}");
+        RenderTaskManager?.Queue(chunkCoord.X >> 4, chunkCoord.Y >> 4);
     }
 
     private void OnGameWorldSave() {
@@ -165,6 +172,7 @@ public sealed class LiveMap {
         _configFileWatcher.Dispose();
 
         Sapi.Event.ChunkDirty -= OnChunkDirty;
+        Sapi.Event.ChunkColumnLoaded -= OnChunkColumnLoaded;
         Sapi.Event.GameWorldSave -= OnGameWorldSave;
 
         Sapi.Event.UnregisterGameTickListener(_gameTickTaskId);

--- a/src/command/CommandHandler.cs
+++ b/src/command/CommandHandler.cs
@@ -8,6 +8,8 @@ namespace livemap.command;
 public class CommandHandler {
     private readonly LiveMap _server;
     private readonly IChatCommand _chatCommand;
+    private readonly List<AbstractCommand> _commands = [];
+    public IEnumerable<AbstractCommand> Commands => _commands;
 
     public CommandHandler(LiveMap server) {
         _server = server;
@@ -18,6 +20,8 @@ public class CommandHandler {
             .RequiresPrivilege(Privilege.chat)
             .HandleWith(_ => "no-args-response".CommandSuccess(server.Config.Web.Url));
 
+        RegisterSubCommand(new HelpCmd(server));
+        RegisterSubCommand(new QueueCmd(server));
         RegisterSubCommand(new ColormapCmd(server));
         RegisterSubCommand(new FullRenderCmd(server));
         RegisterSubCommand(new ApothemRenderCmd(server));
@@ -26,6 +30,8 @@ public class CommandHandler {
     }
 
     private void RegisterSubCommand(AbstractCommand command) {
+        _commands.Add(command);
+
         _chatCommand
             .BeginSubCommands(command.Name)
             .WithDescription(command.Description)

--- a/src/command/subcommand/HelpCmd.cs
+++ b/src/command/subcommand/HelpCmd.cs
@@ -1,0 +1,18 @@
+using System.Text;
+using livemap.util;
+using Vintagestory.API.Common;
+
+namespace livemap.command.subcommand;
+
+public class HelpCmd(LiveMap server) : AbstractCommand(server, ["help"]) {
+    public override TextCommandResult Execute(TextCommandCallingArgs args) {
+        StringBuilder sb = new();
+        sb.AppendLine("Available Commands:");
+
+        foreach (AbstractCommand cmd in _server.CommandHandler.Commands) {
+            sb.AppendLine($"  {cmd.Name[0]} - {cmd.Description}");
+        }
+
+        return TextCommandResult.Success(sb.ToString());
+    }
+}

--- a/src/command/subcommand/QueueCmd.cs
+++ b/src/command/subcommand/QueueCmd.cs
@@ -1,0 +1,18 @@
+using livemap.util;
+using Vintagestory.API.Common;
+
+namespace livemap.command.subcommand;
+
+public class QueueCmd(LiveMap server) : AbstractCommand(server, ["queue"]) {
+    public override TextCommandResult Execute(TextCommandCallingArgs args) {
+        if (_server.RenderTaskManager == null) {
+            return TextCommandResult.Success("Render task manager is not active.");
+        }
+
+        (int buffer, int process) = _server.RenderTaskManager.GetCounts();
+        string status = _server.RenderTaskManager.IsRunning ? "Running" : "Stopped";
+        int colormapCount = _server.Colormap.Count;
+
+        return TextCommandResult.Success($"Render Queue Status: {status}\nBuffer Queue: {buffer}\nProcess Queue: {process}\nColormap Entries: {colormapCount}");
+    }
+}

--- a/src/task/RenderTaskManager.cs
+++ b/src/task/RenderTaskManager.cs
@@ -22,6 +22,8 @@ public sealed class RenderTaskManager {
     private bool _running;
     private bool _stopped;
 
+    public bool IsRunning => _running;
+
     public RenderTaskManager(LiveMap server) {
         _server = server;
 
@@ -70,6 +72,7 @@ public sealed class RenderTaskManager {
 
     public void ProcessQueue() {
         if (_stopped) {
+            Logger.Debug("ProcessQueue skipped: Stopped");
             return;
         }
 
@@ -83,6 +86,8 @@ public sealed class RenderTaskManager {
         while (_bufferQueue.TryDequeue(out long region)) {
             _processQueue.Add(region);
         }
+
+        if (_processQueue.Count > 0) Logger.Debug($"ProcessQueue moved items. Processing {_processQueue.Count} regions...");
 
         if (_running) {
             // this task is still running, no need to restart it


### PR DESCRIPTION
Fixes a bug where exploring wouldn't queue chunks to be rendered unless they were dirtied. This PR now fixes that by queueing up chunks on load. 