### PR TITLE
Fix: materialize map positions to avoid repeated DB queries

### DIFF
--- a/src/data/ChunkLoader.cs
+++ b/src/data/ChunkLoader.cs
@@ -44,9 +44,13 @@ public class ChunkLoader {
         using SqliteCommand sqlite = _sqliteConn.CreateCommand();
         sqlite.CommandText = $"SELECT position FROM map{type}";
         using SqliteDataReader reader = sqlite.ExecuteReader();
+
+        // Materialize to a list
+        var positions = new List<ChunkPos>();
         while (reader.Read()) {
-            yield return ChunkPos.FromChunkIndex_saveGamev2((ulong)(long)reader["position"]);
+            positions.Add(ChunkPos.FromChunkIndex_saveGamev2((ulong)(long)reader["position"]));
         }
+        return positions;
     }
 
     public ServerMapRegion? GetMapRegion(ulong position) {


### PR DESCRIPTION
This PR fixes an issue where map positions were re-queried due to deferred execution.

The query is now materialized into a list, preventing repeated database access when enumerated multiple times.

Fixes #12