### PR TITLE
CRITICAL: SqliteCommand Not Disposed - Resource Leak

### DIFF
--- a/src/data/ChunkLoader.cs
+++ b/src/data/ChunkLoader.cs
@@ -71,7 +71,7 @@ public class ChunkLoader {
     }
 
     private byte[]? GetTableData(ulong index, string name) {
-        SqliteCommand sqlite = _sqliteConn.CreateCommand();
+        using SqliteCommand sqlite = _sqliteConn.CreateCommand();
         sqlite.CommandText = $"SELECT data FROM {name} WHERE position=@pos";
         sqlite.Parameters.Add(new SqliteParameter {
             ParameterName = "pos",


### PR DESCRIPTION
This is a PR to address the referenced critical issue: #2 

- Added a `using` statement to the `SqliteCommand` created in `GetTableData()`
- Should now automatically dispose of the `SqliteCommand` to help prevent resource leaks 