### PR TITLE
fix: resolve critical bugs and refactor magic numbers

### DIFF
--- a/src/LiveMapClient.cs
+++ b/src/LiveMapClient.cs
@@ -60,7 +60,7 @@ public sealed class LiveMapClient {
                             int currentMonth = month; // Fix access to modified closure
 
                             _logger.Event($"Generating colormap for month {month}...");
-                            api.Event.EnqueueMainThreadTask(() => api.ShowChatMessage("command.colormap.generating-month".ToLang(currentMonth)), "livemap-chat");
+                            api.Event.EnqueueMainThreadTask(() => api.ShowChatMessage("colormap.generating-month".ToLang(currentMonth)), "livemap-chat");
 
                             if (_channel is not { Connected: true }) {
                                 _logger.Warning("[LiveMap] Connection lost during colormap generation. Aborting.");

--- a/src/data/ChunkLoader.cs
+++ b/src/data/ChunkLoader.cs
@@ -91,8 +91,8 @@ public class ChunkLoader {
         try {
             _chunkDataPool.SlowDispose();
             _sqliteConn.Close();
-        } catch (Exception) {
-            // ignore
+        } catch (Exception e) {
+            Logger.Warn($"Failed to dispose ChunkLoader: {e.Message}");
         }
     }
 }

--- a/src/data/Colormap.cs
+++ b/src/data/Colormap.cs
@@ -62,7 +62,7 @@ public sealed class Colormap {
     }
 
     public void LoadFromPacket(IWorldAccessor world, ColormapPacket packet) {
-        new Thread(_ => {
+        Task.Run(() => {
             if (Deserialize(packet.Decompress().RawColormap)) {
                 SaveToDisk(packet.Month);
                 RefreshIds(world);
@@ -70,11 +70,11 @@ public sealed class Colormap {
             } else {
                 Logger.Warn("colormap.could-not-save-to-disk".ToLang());
             }
-        }).Start();
+        });
     }
 
     public void LoadFromDisk(IWorldAccessor world, int month = -1) {
-        new Thread(_ => {
+        Task.Run(() => {
             string? json = null;
             string path = month > 0 ? Files.GetColormapFile(month) : Files.ColormapFile;
 
@@ -113,7 +113,7 @@ public sealed class Colormap {
             } else {
                 Logger.Warn("colormap.could-not-load-from-disk".ToLang());
             }
-        }).Start();
+        });
     }
 
     public void SaveToDisk(int month = -1) {

--- a/src/httpd/WebServer.cs
+++ b/src/httpd/WebServer.cs
@@ -101,8 +101,8 @@ public partial class WebServer(LiveMap server) {
 
                     urlLoc = group6[1..];
                 }
-            } catch {
-                // ignore
+            } catch (Exception e) {
+                Logger.Warn($"Failed to parse friendly URL '{urlLoc}': {e.Message}");
             }
 
             if (string.IsNullOrEmpty(urlLoc)) {
@@ -131,8 +131,8 @@ public partial class WebServer(LiveMap server) {
                 try {
                     TimeSpan time = File.GetLastWriteTimeUtc(filePath) - DateTime.UnixEpoch;
                     etag = ((long)time.TotalMilliseconds).ToString();
-                } catch {
-                    // ignore ETag calculation errors
+                } catch (Exception e) {
+                    Logger.Warn($"Failed to calculate ETag for '{filePath}': {e.Message}");
                 }
 
                 IResponseBuilder response = AddCorsHeaders(request.Respond())
@@ -205,8 +205,8 @@ public partial class WebServer(LiveMap server) {
             foreach (IPAddress ip in host.AddressList.Where(ip => ip.AddressFamily == AddressFamily.InterNetwork)) {
                 Logger.Info($"\thttp://{ip}:{port}/");
             }
-        } catch {
-            // ignore DNS errors
+        } catch (Exception e) {
+            Logger.Warn($"Failed to resolve host addresses: {e.Message}");
         }
     }
 

--- a/src/layer/builtin/TradersLayer.cs
+++ b/src/layer/builtin/TradersLayer.cs
@@ -25,8 +25,8 @@ public class TradersLayer : Layer {
             try {
                 string json = File.ReadAllText(_knownFile);
                 traders = JsonConvert.DeserializeObject<ConcurrentDictionary<ulong, HashSet<Trader>>>(json);
-            } catch (Exception) {
-                // ignored
+            } catch (Exception e) {
+                Logger.Warn($"Failed to load traders from '{_knownFile}': {e.Message}");
             }
         }
 

--- a/src/layer/marker/Marker.cs
+++ b/src/layer/marker/Marker.cs
@@ -59,8 +59,8 @@ public class Marker {
     public static T FromJson<T>(string json) {
         try {
             return JsonConvert.DeserializeObject<T>(json) ?? throw new NullReferenceException("null");
-        } catch (Exception) {
-            Console.Error.WriteLine($"Error deserializing marker json ({json})");
+        } catch (Exception e) {
+            Logger.Error($"Error deserializing marker json ({json}): {e}");
             throw;
         }
     }

--- a/src/render/BasicRenderer.cs
+++ b/src/render/BasicRenderer.cs
@@ -1,3 +1,4 @@
+using livemap.util;
 using Vintagestory.API.MathTools;
 
 namespace livemap.render;
@@ -8,8 +9,8 @@ public class BasicRenderer() : Renderer("basic") {
             return;
         }
 
-        for (int x = 0; x < 512; x++) {
-            for (int z = 0; z < 512; z++) {
+        for (int x = 0; x < TileConstants.RegionSize; x++) {
+            for (int z = 0; z < TileConstants.RegionSize; z++) {
                 BlockData.Data? block = blockData.Get(x, z);
                 if (block == null) {
                     continue;

--- a/src/render/BlockData.cs
+++ b/src/render/BlockData.cs
@@ -1,10 +1,12 @@
+using livemap.util;
+
 namespace livemap.render;
 
 public class BlockData {
-    private readonly Data[] _data = new Data[512 * 512];
+    private readonly Data[] _data = new Data[TileConstants.RegionBlockCount];
 
     public Data? Get(int x, int z) {
-        if (x is < 0 or > 511 || z is < 0 or > 511) {
+        if (x is < 0 or > TileConstants.RegionMaxIndex || z is < 0 or > TileConstants.RegionMaxIndex) {
             // todo - i really want to get the edge data from the neighbor regions..
             return null;
         }
@@ -14,7 +16,7 @@ public class BlockData {
 
     public void Set(int x, int z, Data data) => _data[Index(x, z)] = data;
 
-    private static int Index(int x, int z) => ((z & 511) * 512) + (x & 511);
+    private static int Index(int x, int z) => ((z & TileConstants.RegionMask) * TileConstants.RegionSize) + (x & TileConstants.RegionMask);
 
     public class Data(int y, int top, int under) {
         public Dictionary<string, object?> Custom = [];

--- a/src/render/SepiaRenderer.cs
+++ b/src/render/SepiaRenderer.cs
@@ -1,3 +1,5 @@
+using livemap.util;
+
 namespace livemap.render;
 
 public class SepiaRenderer() : Renderer("sepia") {
@@ -16,8 +18,8 @@ public class SepiaRenderer() : Renderer("sepia") {
             return;
         }
 
-        for (int x = 0; x < 512; x++) {
-            for (int z = 0; z < 512; z++) {
+        for (int x = 0; x < TileConstants.RegionSize; x++) {
+            for (int z = 0; z < TileConstants.RegionSize; z++) {
                 BlockData.Data? block = blockData.Get(x, z);
                 if (block == null) {
                     continue;

--- a/src/task/AsyncTask.cs
+++ b/src/task/AsyncTask.cs
@@ -1,3 +1,5 @@
+using livemap.util;
+
 namespace livemap.task;
 
 public abstract class AsyncTask(LiveMap server) {
@@ -15,7 +17,7 @@ public abstract class AsyncTask(LiveMap server) {
             _running = true;
             await TickAsync(_cts.Token);
         } catch (Exception e) {
-            await Console.Error.WriteLineAsync(e.ToString());
+            Logger.Error(e.ToString());
         } finally {
             _running = false;
         }

--- a/src/task/AsyncTaskManager.cs
+++ b/src/task/AsyncTaskManager.cs
@@ -1,3 +1,5 @@
+using livemap.util;
+
 namespace livemap.task;
 
 public class AsyncTaskManager {
@@ -13,7 +15,7 @@ public class AsyncTaskManager {
             try {
                 task.Tick();
             } catch (Exception e) {
-                Console.Error.WriteLine(e.ToString());
+                Logger.Error(e.ToString());
             }
         }
     }
@@ -23,7 +25,7 @@ public class AsyncTaskManager {
             try {
                 task.Dispose();
             } catch (Exception e) {
-                Console.Error.WriteLine(e.ToString());
+                Logger.Error(e.ToString());
             }
         }
     }

--- a/src/task/MarkersTask.cs
+++ b/src/task/MarkersTask.cs
@@ -36,7 +36,7 @@ public class MarkersTask(LiveMap server) : AsyncTask(server) {
             try {
                 await layer.WriteToDisk(cancellationToken);
             } catch (Exception e) {
-                await Console.Error.WriteLineAsync(e.ToString());
+                Logger.Error(e.ToString());
             }
         }
 

--- a/src/task/RenderTask.cs
+++ b/src/task/RenderTask.cs
@@ -197,8 +197,8 @@ public sealed class RenderTask(LiveMap server, RenderTaskManager renderTaskManag
                 under = serverChunk.Data[Mathf.BlockIndex(x, y - 1, z)];
                 CheckForMicroBlocks(x, y - 1, z, chunkPos, serverChunk, ref under);
             }
-        } catch (Exception) {
-            // ignore
+        } catch (Exception e) {
+            Logger.Debug($"Failed to scan block column at ({x}, {y}, {z}) in chunk {chunkPos}: {e.Message}");
         }
 
         return new BlockData.Data(y, top, under);

--- a/src/task/RenderTaskManager.cs
+++ b/src/task/RenderTaskManager.cs
@@ -11,6 +11,7 @@ public sealed class RenderTaskManager {
     private readonly ConcurrentQueue<long> _bufferQueue = new();
     private readonly BlockingCollection<long> _processQueueHigh = [];
     private readonly BlockingCollection<long> _processQueueLow = [];
+    private readonly object _queueLock = new();
     private readonly LiveMap _server;
     private bool _stopped;
 
@@ -59,16 +60,18 @@ public sealed class RenderTaskManager {
         // convert region coordinates to long
         long index = Mathf.AsLong(regionX, regionZ);
 
-        // ensure this region hasn't already been queued up
-        bool inHigh = _processQueueHigh.Contains(index);
-        bool inLow = _processQueueLow.Contains(index);
+        lock (_queueLock) {
+            // ensure this region hasn't already been queued up
+            bool inHigh = _processQueueHigh.Contains(index);
+            bool inLow = _processQueueLow.Contains(index);
 
-        if (_bufferQueue.Contains(index) || inHigh || inLow) {
-            return;
+            if (_bufferQueue.Contains(index) || inHigh || inLow) {
+                return;
+            }
+
+            // queue it up to the buffer, so it doesn't get process immediately
+            _bufferQueue.Enqueue(index);
         }
-
-        // queue it up to the buffer, so it doesn't get process immediately
-        _bufferQueue.Enqueue(index);
 
         Logger.Debug($"Queueing region {regionX},{regionZ} (buffer: {_bufferQueue.Count} high:{_processQueueHigh.Count} low:{_processQueueLow.Count})");
     }
@@ -78,23 +81,25 @@ public sealed class RenderTaskManager {
             return;
         }
 
-        HashSet<long> existing = [.. _bufferQueue];
-        foreach (long region in _processQueueHigh) {
-            existing.Add(region);
-        }
-
-        foreach (long region in _processQueueLow) {
-            existing.Add(region);
-        }
-
         int count = 0;
-        foreach (long index in ChunkLoader.GetAllMapRegionPositions().Select(pos => Mathf.AsLong(pos.X, pos.Z))) {
-            if (existing.Contains(index)) {
-                continue;
+        lock (_queueLock) {
+            HashSet<long> existing = [.. _bufferQueue];
+            foreach (long region in _processQueueHigh) {
+                existing.Add(region);
             }
 
-            _bufferQueue.Enqueue(index);
-            count++;
+            foreach (long region in _processQueueLow) {
+                existing.Add(region);
+            }
+
+            foreach (long index in ChunkLoader.GetAllMapRegionPositions().Select(pos => Mathf.AsLong(pos.X, pos.Z))) {
+                if (existing.Contains(index)) {
+                    continue;
+                }
+
+                _bufferQueue.Enqueue(index);
+                count++;
+            }
         }
 
         Logger.Info($"Queued {count} regions for full render.");
@@ -142,8 +147,8 @@ public sealed class RenderTaskManager {
 
                     ProcessRegion(region);
                 }
-            } catch (Exception) {
-                // ignore
+            } catch (Exception e) {
+                Logger.Error($"Render task processing failed: {e}");
             }
 
             IsRunning = false;

--- a/src/task/SettingsTask.cs
+++ b/src/task/SettingsTask.cs
@@ -76,7 +76,7 @@ public sealed class SettingsTask(LiveMap server) : AsyncTask(server) {
 
             await Files.WriteJsonAsync(Path.Combine(Files.JsonDir, "settings.json"), json, cancellationToken);
         } catch (Exception e) {
-            await Console.Error.WriteLineAsync(e.ToString());
+            Logger.Error(e.ToString());
         }
     }
 

--- a/src/tile/TileImage.cs
+++ b/src/tile/TileImage.cs
@@ -77,8 +77,6 @@ public unsafe class TileImage {
                     _bitmap.Encode(config.Web.TileType.Format, config.Web.TileQuality).SaveTo(outStream);
                 }
             }
-
-            _bitmap.Dispose();
         } catch (Exception e) {
             Logger.Error(e.ToString());
         }

--- a/src/tile/TileImage.cs
+++ b/src/tile/TileImage.cs
@@ -19,9 +19,9 @@ public unsafe class TileImage {
     private readonly byte[] _shadowMap;
 
     public TileImage(int regionX, int regionZ) {
-        _bitmap = new SKBitmap(512, 512);
+        _bitmap = new SKBitmap(TileConstants.RegionSize, TileConstants.RegionSize);
         _bitmapPtr = (byte*)_bitmap.GetPixels().ToPointer();
-        _shadowMap = new byte[512 << 9].Fill((byte)128);
+        _shadowMap = new byte[TileConstants.RegionBlockCount].Fill((byte)128);
 
         _bitmapRowBytes = _bitmap.RowBytes;
 
@@ -30,23 +30,23 @@ public unsafe class TileImage {
     }
 
     public void SetBlockColor(int blockX, int blockZ, uint argb, float yDiff) {
-        int imgX = blockX & 511;
-        int imgZ = blockZ & 511;
+        int imgX = blockX & TileConstants.RegionMask;
+        int imgZ = blockZ & TileConstants.RegionMask;
 
         ((uint*)(_bitmapPtr + (imgZ * _bitmapRowBytes)))[imgX] = argb;
 
-        _shadowMap[(imgZ << 9) + imgX] = (byte)(_shadowMap[(imgZ << 9) + imgX] * yDiff);
+        _shadowMap[(imgZ << TileConstants.RegionSizeBitShift) + imgX] = (byte)(_shadowMap[(imgZ << TileConstants.RegionSizeBitShift) + imgX] * yDiff);
     }
 
     public void CalculateShadows() {
         byte[] shadowMapCopy = [.. _shadowMap];
-        BlurTool.Blur(_shadowMap, 512, 512, 2);
+        BlurTool.Blur(_shadowMap, TileConstants.RegionSize, TileConstants.RegionSize, 2);
         for (int i = 0; i < _shadowMap.Length; i++) {
             float shadow = (int)(((_shadowMap[i] / 128F) - 1F) * 5F) / 5F;
             shadow += ((shadowMapCopy[i] / 128F) - 1F) * 5F % 1F / 5F;
 
-            int imgX = i & 511;
-            int imgZ = i >> 9;
+            int imgX = i & TileConstants.RegionMask;
+            int imgZ = i >> TileConstants.RegionSizeBitShift;
 
             uint* row = (uint*)(_bitmapPtr + (imgZ * _bitmapRowBytes));
             row[imgX] = (uint)(row[imgX] == 0 ? 0 : ColorUtil.ColorMultiply3Clamped((int)row[imgX], (shadow * 1.4F) + 1F));
@@ -63,7 +63,7 @@ public unsafe class TileImage {
                 if (zoom > 0) {
                     SKBitmap bitmap;
                     using (FileStream inStream = fileInfo.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read)) {
-                        bitmap = SKBitmap.Decode(inStream) ?? new SKBitmap(512, 512);
+                        bitmap = SKBitmap.Decode(inStream) ?? new SKBitmap(TileConstants.RegionSize, TileConstants.RegionSize);
                     }
 
                     WritePixels(bitmap, zoom);
@@ -84,12 +84,12 @@ public unsafe class TileImage {
 
     private void WritePixels(SKBitmap png, int zoom) {
         int step = 1 << zoom;
-        int baseX = ((_regionX * 512) >> zoom) & 511;
-        int baseZ = ((_regionZ * 512) >> zoom) & 511;
+        int baseX = ((_regionX * TileConstants.RegionSize) >> zoom) & TileConstants.RegionMask;
+        int baseZ = ((_regionZ * TileConstants.RegionSize) >> zoom) & TileConstants.RegionMask;
         byte* pngPtr = (byte*)png.GetPixels().ToPointer();
         int pngRowBytes = png.RowBytes;
-        for (int x = 0; x < 512; x += step) {
-            for (int z = 0; z < 512; z += step) {
+        for (int x = 0; x < TileConstants.RegionSize; x += step) {
+            for (int z = 0; z < TileConstants.RegionSize; z += step) {
                 uint argb = ((uint*)(_bitmapPtr + (z * _bitmapRowBytes)))[x];
                 if (argb == 0) {
                     // skipping 0 prevents overwrite existing

--- a/src/tile/TileImage.cs
+++ b/src/tile/TileImage.cs
@@ -68,13 +68,13 @@ public unsafe class TileImage {
 
                     WritePixels(bitmap, zoom);
 
-                    using (FileStream outStream = fileInfo.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read)) {
+                    using (FileStream outStream = fileInfo.Open(FileMode.Create, FileAccess.Write, FileShare.Read)) {
                         bitmap.Encode(config.Web.TileType.Format, config.Web.TileQuality).SaveTo(outStream);
                     }
 
                     bitmap.Dispose();
                 } else {
-                    using FileStream outStream = fileInfo.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+                    using FileStream outStream = fileInfo.Open(FileMode.Create, FileAccess.Write, FileShare.Read);
                     _bitmap.Encode(config.Web.TileType.Format, config.Web.TileQuality).SaveTo(outStream);
                 }
             }

--- a/src/tile/TileImage.cs
+++ b/src/tile/TileImage.cs
@@ -61,13 +61,16 @@ public unsafe class TileImage {
                 GamePaths.EnsurePathExists(fileInfo.Directory!.FullName);
 
                 if (zoom > 0) {
-                    using FileStream inStream = fileInfo.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
-                    SKBitmap bitmap = SKBitmap.Decode(inStream) ?? new SKBitmap(512, 512);
+                    SKBitmap bitmap;
+                    using (FileStream inStream = fileInfo.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read)) {
+                        bitmap = SKBitmap.Decode(inStream) ?? new SKBitmap(512, 512);
+                    }
 
                     WritePixels(bitmap, zoom);
 
-                    using FileStream outStream = fileInfo.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
-                    bitmap.Encode(config.Web.TileType.Format, config.Web.TileQuality).SaveTo(outStream);
+                    using (FileStream outStream = fileInfo.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read)) {
+                        bitmap.Encode(config.Web.TileType.Format, config.Web.TileQuality).SaveTo(outStream);
+                    }
                     bitmap.Dispose();
                 } else {
                     using FileStream outStream = fileInfo.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);

--- a/src/tile/TileImage.cs
+++ b/src/tile/TileImage.cs
@@ -71,6 +71,7 @@ public unsafe class TileImage {
                     using (FileStream outStream = fileInfo.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read)) {
                         bitmap.Encode(config.Web.TileType.Format, config.Web.TileQuality).SaveTo(outStream);
                     }
+
                     bitmap.Dispose();
                 } else {
                     using FileStream outStream = fileInfo.Open(FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);

--- a/src/util/Files.cs
+++ b/src/util/Files.cs
@@ -45,8 +45,8 @@ public abstract class Files {
                     if (existingData.SequenceEqual(asset.Data)) {
                         continue;
                     }
-                } catch (Exception) {
-                    // ignore read errors, just overwrite
+                } catch (Exception e) {
+                    Logger.Debug($"Failed to read existing file '{destPath}', will overwrite: {e.Message}");
                 }
             }
 

--- a/src/util/TileConstants.cs
+++ b/src/util/TileConstants.cs
@@ -1,0 +1,28 @@
+namespace livemap.util;
+
+public static class TileConstants {
+    /// <summary>
+    /// The size of a region/tile in blocks (512x512)
+    /// </summary>
+    public const int RegionSize = 512;
+
+    /// <summary>
+    /// Maximum index for region coordinates (RegionSize - 1)
+    /// </summary>
+    public const int RegionMaxIndex = RegionSize - 1;
+
+    /// <summary>
+    /// Bitmask for wrapping coordinates within a region
+    /// </summary>
+    public const int RegionMask = RegionMaxIndex;
+
+    /// <summary>
+    /// Total number of blocks in a region (RegionSize * RegionSize)
+    /// </summary>
+    public const int RegionBlockCount = RegionSize * RegionSize;
+
+    /// <summary>
+    /// Bit shift value for region size (log2(512) = 9)
+    /// </summary>
+    public const int RegionSizeBitShift = 9;
+}


### PR DESCRIPTION
## Summary
This PR addresses 7 bugs across CRITICAL, HIGH, MEDIUM, and REFACTOR priority levels, improving stability, thread safety, and code maintainability.

## Bug Fixes

### CRITICAL

**#1 - Thread Leak in Colormap.cs**
- Replaced untracked `new Thread().Start()` calls with `Task.Run()` 
- Affects `LoadFromPacket()` and `LoadFromDisk()` methods
- Uses thread pool instead of creating unmanaged threads
- Prevents resource exhaustion under load

**#3 - File Lock Issues in TileImage.cs**
- Fixed concurrent file access in `Save()` method
- Properly scopes FileStream disposal to prevent simultaneous read/write
- Eliminates file locking exceptions during tile generation

### HIGH

**#4 - Race Condition in RenderTaskManager**
- Added `_queueLock` to make check-and-enqueue operations atomic
- Prevents duplicate regions in render queue
- Applied to both `Queue()` and `QueueAll()` methods

**#5 - Bitmap Thread Safety**
- Removed premature bitmap disposal in `Save()` method
- Fixes double-dispose issue and invalid pointer access
- Bitmap now only disposed in `Dispose()` method

**#6 - Inconsistent Error Logging**
- Replaced all `Console.Error.WriteLine` with `Logger.Error`
- Standardized error logging across 6 locations:
  - src/layer/marker/Marker.cs
  - src/task/AsyncTaskManager.cs (2 locations)
  - src/task/MarkersTask.cs
  - src/task/AsyncTask.cs
  - src/task/SettingsTask.cs

### MEDIUM

**#9 - Empty Catch Blocks**
- Added meaningful error logging to 8 empty catch blocks
- Improved debugging capability across:
  - src/httpd/WebServer.cs (3 locations)
  - src/util/Files.cs
  - src/data/ChunkLoader.cs
  - src/layer/builtin/TradersLayer.cs
  - src/task/RenderTaskManager.cs
  - src/task/RenderTask.cs

### REFACTOR

**#18 - Magic Numbers**
- Created `TileConstants` class with well-documented constants
- Replaced all hardcoded `512` values with named constants:
  - `RegionSize` - tile size in blocks
  - `RegionMaxIndex` - maximum coordinate index
  - `RegionMask` - bitmask for coordinate wrapping
  - `RegionBlockCount` - total blocks per region
  - `RegionSizeBitShift` - bit shift value for optimizations
- Improves code readability and maintainability

## Testing
- ✅ Build succeeded with no errors
- All changes are backward compatible
- No API changes

## Notes
Bugs #19 (God Class refactoring) and #20 (Null-checking patterns) are deferred for future work as they require extensive architectural changes.