### PR TITLE
Fix: Stop polling hidden marker layers

### DIFF
--- a/web/src/layer/MarkersLayer.ts
+++ b/web/src/layer/MarkersLayer.ts
@@ -84,6 +84,10 @@ export class MarkersLayer extends L.LayerGroup {
 	}
 
 	public tick(count: number): void {
+		if (this._initialized && !this._livemap.hasLayer(this)) {
+			return;
+		}
+
 		if (count % (this._interval ?? 0) === 0) {
 			this.updateLayer();
 		}


### PR DESCRIPTION
This PR modifies front to prevent it from fetching updates when the layer is not currently active/visible on the map.

While this is some improvement, it addresses the symptom of the polling architecture. A more robust long-term solution would be implementing WebSockets and Webhooks to push updates to the client only when necessary. However, this change slightly reduces "bombarding" server with requests in the current setup without requiring a backend rewrite.